### PR TITLE
Refactor NavBar to match new branding

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -6,114 +6,30 @@ import Link from "next/link";
 export default function NavBar() {
   const [open, setOpen] = useState(false);
 
-  const desktopLinks = (
-    <ul className="hidden md:flex items-center space-x-6 text-lg">
-      <li>
-        <Link href="/" className="hover:text-birthday-gold">Home</Link>
-      </li>
-      <li>
-        <Link href="/signup" className="hover:text-birthday-gold">Signup</Link>
-      </li>
-      <li>
-        <Link href="/dashboard" className="hover:text-birthday-gold">Dashboard</Link>
-      </li>
-      <li>
-        <Link href="/events" className="hover:text-birthday-gold">Events</Link>
-      </li>
-      <li>
-        <Link href="/events/create" className="hover:text-birthday-gold">Create Event</Link>
-      </li>
-      <li className="relative group">
-        <span className="cursor-pointer hover:text-birthday-gold">Tiers ▾</span>
-        <ul className="absolute left-0 hidden group-hover:block bg-gradient-to-br from-birthday-blue to-birthday-purple text-white mt-2 rounded shadow-lg whitespace-nowrap">
-          <li>
-            <Link href="/tiers/galaxy" className="block px-4 py-2 hover:text-birthday-gold">Galaxy</Link>
-          </li>
-          <li>
-            <Link href="/tiers/elite" className="block px-4 py-2 hover:text-birthday-gold">Elite</Link>
-          </li>
-          <li>
-            <Link href="/tiers/cosmic" className="block px-4 py-2 hover:text-birthday-gold">Cosmic</Link>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <Link href="/profile" className="hover:text-birthday-gold">Profile</Link>
-      </li>
-      <li>
-        <Link href="/admin" className="hover:text-birthday-gold">Admin</Link>
-      </li>
-      <li>
-        <Link href="/legal" className="hover:text-birthday-gold">Legal</Link>
-      </li>
-    </ul>
-  );
+  const links = [
+    { href: "/", label: "Home" },
+    { href: "/signup", label: "Signup" },
+    { href: "/dashboard", label: "Dashboard" },
+    { href: "/events", label: "Events" },
+    { href: "/events/create", label: "Create Event" },
+    { href: "/profile", label: "Profile" },
+    { href: "/admin", label: "Admin" },
+    { href: "/legal", label: "Legal" },
+  ];
 
-  const mobileLinks = (
-    <ul className="md:hidden flex flex-col space-y-2 p-4 bg-gradient-to-b from-birthday-blue via-birthday-purple to-black text-lg">
-      <li>
-        <Link href="/" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Home
-        </Link>
-      </li>
-      <li>
-        <Link href="/signup" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Signup
-        </Link>
-      </li>
-      <li>
-        <Link href="/dashboard" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Dashboard
-        </Link>
-      </li>
-      <li>
-        <Link href="/events" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Events
-        </Link>
-      </li>
-      <li>
-        <Link href="/events/create" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Create Event
-        </Link>
-      </li>
-      <li className="pl-2 font-semibold text-birthday-gold">Tiers</li>
-      <li className="ml-4">
-        <Link href="/tiers/galaxy" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Galaxy
-        </Link>
-      </li>
-      <li className="ml-4">
-        <Link href="/tiers/elite" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Elite
-        </Link>
-      </li>
-      <li className="ml-4">
-        <Link href="/tiers/cosmic" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Cosmic
-        </Link>
-      </li>
-      <li>
-        <Link href="/profile" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Profile
-        </Link>
-      </li>
-      <li>
-        <Link href="/admin" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Admin
-        </Link>
-      </li>
-      <li>
-        <Link href="/legal" className="block hover:text-birthday-gold" onClick={() => setOpen(false)}>
-          Legal
-        </Link>
-      </li>
-    </ul>
-  );
+  const tierLinks = [
+    { href: "/tiers/galaxy", label: "Galaxy" },
+    { href: "/tiers/elite", label: "Elite" },
+    { href: "/tiers/cosmic", label: "Cosmic" },
+  ];
+
+  const linkClass =
+    "whitespace-nowrap hover:underline hover:decoration-[#FFD700] hover:text-[#FFD700]";
 
   return (
-    <header className="relative z-50 bg-gradient-to-r from-birthday-blue via-birthday-purple to-black text-white shadow-lg">
-      <div className="max-w-7xl mx-auto flex items-center justify-between p-4">
-        <Link href="/" className="text-xl font-bold whitespace-nowrap">
+    <header className="relative z-50 bg-gradient-to-r from-[#0a0a5b] to-[#4b0082] text-white">
+      <div className="max-w-7xl mx-auto flex items-center justify-between py-3 px-4">
+        <Link href="/" className="text-lg md:text-xl font-bold">
           🎂 Birthday Link
         </Link>
         <button
@@ -123,9 +39,59 @@ export default function NavBar() {
         >
           ☰
         </button>
-        {desktopLinks}
+        <ul className="hidden md:flex items-center space-x-6 text-sm md:text-base lg:text-lg">
+          {links.slice(0, 5).map((l) => (
+            <li key={l.href}>
+              <Link href={l.href} className={linkClass}>
+                {l.label}
+              </Link>
+            </li>
+          ))}
+          <li className="relative group">
+            <span className="cursor-pointer">Tiers ▾</span>
+            <ul className="absolute left-0 hidden group-hover:block bg-[#0a0a5b] text-white mt-2 rounded shadow-lg">
+              {tierLinks.map((t) => (
+                <li key={t.href}>
+                  <Link href={t.href} className="block px-4 py-2 hover:text-[#FFD700]">
+                    {t.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+          {links.slice(5).map((l) => (
+            <li key={l.href}>
+              <Link href={l.href} className={linkClass}>
+                {l.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
-      {open && mobileLinks}
+      <div
+        className={`fixed inset-0 z-40 transition-transform duration-300 md:hidden ${open ? "translate-x-0" : "translate-x-full pointer-events-none"}`}
+      >
+        <div className="absolute inset-0 bg-black/60" onClick={() => setOpen(false)} />
+        <div className="absolute right-0 top-0 h-full w-2/3 sm:w-1/2 bg-[#0a0a5b] p-6 space-y-4 text-[#FFD700]">
+          <ul className="flex flex-col text-lg">
+            {links.map((l) => (
+              <li key={l.href}>
+                <Link href={l.href} onClick={() => setOpen(false)} className="block py-1">
+                  {l.label}
+                </Link>
+              </li>
+            ))}
+            <li className="font-semibold pt-2">Tiers</li>
+            {tierLinks.map((t) => (
+              <li key={t.href} className="ml-2">
+                <Link href={t.href} onClick={() => setOpen(false)} className="block py-1">
+                  {t.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- redesign navigation bar using a deep-blue to purple gradient
- use white and birthday-gold highlights with modern responsive font sizes
- add dropdown tier menu and sliding mobile drawer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6874ea29e650832998b64cbbcecff5bf